### PR TITLE
Bump version to 0.0.4

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Alexander Kolupaev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -15,12 +15,20 @@
 2. Click on "Add to Chrome".
 3. Enable the extension.
 
-<!-- ## Load unpacked extension from source -->
 ## Build and install extension from source
 
-1. Clone the repository - `git clone git@github.com:theonekeyg/duckling.git`.
-2. Install dependencies - `pnpm install`.
-3. Build the extension bundle - `pnpm build`.
+1. Clone the repository
+```bash
+git clone git@github.com:theonekeyg/duckling.git
+```
+2. Install dependencies
+```bash
+pnpm install
+```
+3. Build the extension bundle
+```
+pnpm build
+```
 4. Open Chrome extension page (chrome://extensions).
 5. Enable "Developer mode" in top right.
 6. Click on "Load unpacked" in the top left and select the directory `.output/chrome-mv3`.

--- a/README.md
+++ b/README.md
@@ -15,11 +15,15 @@
 2. Click on "Add to Chrome".
 3. Enable the extension.
 
-## Load unpacked extension from source
+<!-- ## Load unpacked extension from source -->
+## Build and install extension from source
 
-1. Open Chrome extensions page (chrome://extensions).
-2. Enable "Developer mode" in top right.
-3. Click on "Load unpacked" in the top left and select the directory of the cloned repo.
+1. Clone the repository - `git clone git@github.com:theonekeyg/duckling.git`.
+2. Install dependencies - `pnpm install`.
+3. Build the extension bundle - `pnpm build`.
+4. Open Chrome extension page (chrome://extensions).
+5. Enable "Developer mode" in top right.
+6. Click on "Load unpacked" in the top left and select the directory `.output/chrome-mv3`.
 
 # Usage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "duckling",
-  "version": "1.0.0",
+  "version": "0.0.4",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -15,6 +15,13 @@ export default defineConfig({
     },
     vite: () => ({
         build: {
+            // Minification is disabled to make review process by distributions easier.
+            // Note from google (https://developer.chrome.com/docs/webstore/review-process#review-time-factors):
+            // '''
+            // Minification is allowed, but it can also make reviewing extension code more difficult.
+            // Where possible, consider submitting your code as authored.
+            // '''
+            // NOTE: Could be enabled it in the future, once reviews are more streamlined and faster.
             minify: false,
         }
     }),

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
         return {
             name: "Duckling",
             description: "Instant DuckDuckGo bangs in your search bar. Local suggestions, no network requests - just type '! <bang> <query>'.",
-            version: "0.0.3",
+            version: "0.0.4",
             minimum_chrome_version: "102",
             omnibox: {
                 keyword: "!",

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     },
     vite: () => ({
         build: {
-            // Minification is disabled to make review process by distributions easier.
+            // Minification is disabled to make review process by distributions easier & faster.
             // Note from google (https://developer.chrome.com/docs/webstore/review-process#review-time-factors):
             // '''
             // Minification is allowed, but it can also make reviewing extension code more difficult.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped app manifest version to 0.0.4.
  * Added an MIT LICENSE to the project.
  * Build defaults updated to disable minification by default.

* **Documentation**
  * Replaced "load unpacked" install steps with a build-and-install workflow: clone, install deps, build, then load the built extension from the output directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->