### PR TITLE
Delete deprecated silent-ignore for using highlight API.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,6 @@ export function initOmnibox(fmtCallbacks: FormatCallbacks) {
             console.log(`redirecting to query: "${query}"`);
             chrome.tabs.update({
                 url: bang.u.replace('{{{s}}}', encodeURIComponent(query)),
-                highlighted: false,
             });
         }
         return;


### PR DESCRIPTION
This was causing errors on redirect since chrome 147.0.7721.0+ (07.04.2026). This commit to chrome broke the extension - https://github.com/chromium/chromium/commit/ebae198bc22dadaa9a84c51d42f48a3d3b777bbd.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved omnibox suggestion handling by streamlining internal configuration to use browser defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theonekeyg/duckling/pull/8?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->